### PR TITLE
chore: Slack SDK for Javaへの依存を排除

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## logbook-kai-plugins
 
-sanaehirotakaさんの航海日誌 ([logbook-kai](https://github.com/sanaehirotaka/logbook-kai)) へのプラグイン集。
+航海日誌 ([logbook-kai](https://github.com/rsky/logbook-kai)) へのプラグイン集。
 
 ## Slackプラグイン
 
@@ -20,10 +20,6 @@ sanaehirotakaさんの航海日誌 ([logbook-kai](https://github.com/sanaehirota
 ### 使用ライブラリとライセンス
 
 以下のライブラリを使用しています。
-
-#### [Slack SDK for Java](https://github.com/slackapi/java-slack-sdk)
-
-- [MIT License](https://github.com/slackapi/java-slack-sdk/blob/main/LICENSE)
 
 #### [RxJava](https://github.com/ReactiveX/RxJava) & [RxJavaFX](https://github.com/ReactiveX/RxJavaFX)
 

--- a/commons/build.gradle
+++ b/commons/build.gradle
@@ -1,5 +1,5 @@
 description = 'logbook-kai-plugin-commons'
-version = '25.9.1'
+version = '25.11.1'
 
 dependencies {
 }

--- a/discord/build.gradle
+++ b/discord/build.gradle
@@ -1,5 +1,5 @@
 description = 'Discord Plugin'
-version = '1.0.0'
+version = '1.0.1'
 
 def bundleName = description
 def rxJavaVersion = '2.2.21'

--- a/discord/src/main/java/plugins/discord/api/Pusher.java
+++ b/discord/src/main/java/plugins/discord/api/Pusher.java
@@ -8,7 +8,7 @@ import javax.json.Json;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
-import java.net.http.HttpResponse.BodyHandlers;
+import java.net.http.HttpResponse;
 
 public class Pusher {
     private final String incomingWebhookUrl;
@@ -51,7 +51,7 @@ public class Pusher {
                     .setHeader("Content-Type", "application/json")
                     .build();
             try {
-                var res = client.send(req, BodyHandlers.ofString());
+                var res = client.send(req, HttpResponse.BodyHandlers.ofString());
                 if (res.statusCode() == 200 && onSuccess != null) {
                     onSuccess.accept(res.body());
                 }

--- a/rankingchart/build.gradle
+++ b/rankingchart/build.gradle
@@ -1,5 +1,5 @@
 description = '戦果チャート Plugin'
-version = '2.0.3'
+version = '2.0.4'
 
 def bundleName = description
 def sqliteVersion = '3.51.0.0'

--- a/slack/build.gradle
+++ b/slack/build.gradle
@@ -5,14 +5,12 @@ def bundleName = description
 def rxJavaVersion = '2.2.21'
 def rxJavaFXVersion = '2.2.2'
 def reactiveStreamsVersion = '1.0.4'
-def slackApiVersion = '1.46.0'
 
 dependencies {
     implementation project(':commons')
     implementation "io.reactivex.rxjava2:rxjava:$rxJavaVersion"
     implementation "io.reactivex.rxjava2:rxjavafx:$rxJavaFXVersion"
     implementation "org.reactivestreams:reactive-streams:$reactiveStreamsVersion"
-    implementation "com.slack.api:slack-api-client:$slackApiVersion"
 }
 
 jar {

--- a/slack/build.gradle
+++ b/slack/build.gradle
@@ -1,5 +1,5 @@
 description = 'Slack Plugin'
-version = '1.3.0'
+version = '1.4.0'
 
 def bundleName = description
 def rxJavaVersion = '2.2.21'


### PR DESCRIPTION
- Slack SDK for Javaを使わずにJava標準の機能を用いてIncoming Webhookのペイロードを組み立て、送信する
- リリース用に各種パッケージのバージョンナンバーを更新
- READMEでlogbook-kaiへのリンクをrskyのリポジトリに変更