### PR TITLE
refactor: RxJava 2からReactorへ移行

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@
 
 以下のライブラリを使用しています。
 
-#### [RxJava](https://github.com/ReactiveX/RxJava) & [RxJavaFX](https://github.com/ReactiveX/RxJavaFX)
+#### [Reactor Core](https://github.com/reactor/reactor-core)
 
-- [Apache License 2.0](https://github.com/ReactiveX/RxJava/blob/3.x/LICENSE) (RxJava)
+- [Apache License 2.0](https://github.com/reactor/reactor-core/blob/main/LICENSE)
 
 #### [Lombok](https://projectlombok.org/)
 
@@ -48,9 +48,9 @@
 
 以下のライブラリを使用しています。
 
-#### [RxJava](https://github.com/ReactiveX/RxJava) & [RxJavaFX](https://github.com/ReactiveX/RxJavaFX)
+#### [Reactor Core](https://github.com/reactor/reactor-core)
 
-- [Apache License 2.0](https://github.com/ReactiveX/RxJava/blob/3.x/LICENSE) (RxJava)
+- [Apache License 2.0](https://github.com/reactor/reactor-core/blob/main/LICENSE)
 
 #### [Lombok](https://projectlombok.org/)
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@
 #### [RxJava](https://github.com/ReactiveX/RxJava) & [RxJavaFX](https://github.com/ReactiveX/RxJavaFX)
 
 - [Apache License 2.0](https://github.com/ReactiveX/RxJava/blob/3.x/LICENSE) (RxJava)
-- [Apache License 2.0](https://github.com/ReactiveX/RxJavaFX/blob/2.x/LICENSE) (RxJavaFx)
 
 #### [Lombok](https://projectlombok.org/)
 
@@ -52,7 +51,6 @@
 #### [RxJava](https://github.com/ReactiveX/RxJava) & [RxJavaFX](https://github.com/ReactiveX/RxJavaFX)
 
 - [Apache License 2.0](https://github.com/ReactiveX/RxJava/blob/3.x/LICENSE) (RxJava)
-- [Apache License 2.0](https://github.com/ReactiveX/RxJavaFX/blob/2.x/LICENSE) (RxJavaFx)
 
 #### [Lombok](https://projectlombok.org/)
 

--- a/discord/build.gradle
+++ b/discord/build.gradle
@@ -2,12 +2,11 @@ description = 'Discord Plugin'
 version = '1.0.1'
 
 def bundleName = description
-def rxJavaVersion = '2.2.21'
-def reactiveStreamsVersion = '1.0.4'
+def reactorVersion = '3.7.12'
 
 dependencies {
     implementation project(':commons')
-    implementation "io.reactivex.rxjava2:rxjava:$rxJavaVersion"
+    implementation "io.projectreactor:reactor-core:$reactorVersion"
 }
 
 jar {

--- a/discord/build.gradle
+++ b/discord/build.gradle
@@ -3,14 +3,11 @@ version = '1.0.1'
 
 def bundleName = description
 def rxJavaVersion = '2.2.21'
-def rxJavaFXVersion = '2.2.2'
 def reactiveStreamsVersion = '1.0.4'
 
 dependencies {
     implementation project(':commons')
     implementation "io.reactivex.rxjava2:rxjava:$rxJavaVersion"
-    implementation "io.reactivex.rxjava2:rxjavafx:$rxJavaFXVersion"
-    implementation "org.reactivestreams:reactive-streams:$reactiveStreamsVersion"
 }
 
 jar {

--- a/discord/src/main/java/plugins/discord/NotificationController.java
+++ b/discord/src/main/java/plugins/discord/NotificationController.java
@@ -1,7 +1,5 @@
 package plugins.discord;
 
-import io.reactivex.Flowable;
-import io.reactivex.schedulers.Schedulers;
 import logbook.Messages;
 import logbook.bean.*;
 import logbook.internal.Ships;
@@ -10,11 +8,11 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import plugins.discord.api.Pusher;
 import plugins.discord.bean.DiscordConfig;
+import reactor.core.publisher.Flux;
 
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 /**
  * プッシュ通知コントローラ
@@ -33,8 +31,7 @@ public class NotificationController implements StartUp {
     @Override
     public void run() {
         // 起動時には通知を飛ばさないように1分待ってから監視を始める
-        Flowable.interval(60, 1, TimeUnit.SECONDS)
-                .observeOn(Schedulers.computation())
+        Flux.interval(Duration.ofSeconds(60), Duration.ofSeconds(1))
                 .subscribe(l -> update(), LoggerHolder::logError);
     }
 

--- a/discord/src/main/java/plugins/discord/api/Pusher.java
+++ b/discord/src/main/java/plugins/discord/api/Pusher.java
@@ -1,6 +1,5 @@
 package plugins.discord.api;
 
-import io.reactivex.functions.Consumer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -9,6 +8,7 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.util.function.Consumer;
 
 public class Pusher {
     private final String incomingWebhookUrl;
@@ -57,11 +57,7 @@ public class Pusher {
                 }
             } catch (Exception e) {
                 if (onError != null) {
-                    try {
-                        onError.accept(e);
-                    } catch (Exception ex) {
-                        throw new RuntimeException(ex);
-                    }
+                    onError.accept(e);
                 } else {
                     LoggerHolder.logError(e);
                 }

--- a/discord/src/main/java/plugins/discord/api/Pusher.java
+++ b/discord/src/main/java/plugins/discord/api/Pusher.java
@@ -52,7 +52,7 @@ public class Pusher {
                     .build();
             try {
                 var res = client.send(req, HttpResponse.BodyHandlers.ofString());
-                if (res.statusCode() == 200 && onSuccess != null) {
+                if (res.statusCode() == 204 && onSuccess != null) {
                     onSuccess.accept(res.body());
                 }
             } catch (Exception e) {

--- a/discord/src/main/java/plugins/discord/gui/DiscordConfigController.java
+++ b/discord/src/main/java/plugins/discord/gui/DiscordConfigController.java
@@ -74,7 +74,7 @@ public class DiscordConfigController extends WindowController {
         new Pusher(incomingWebhookUrl.getText()).push(
                 "送信テスト",
                 "航海日誌 Discord Plugin より",
-                pushes -> Platform.runLater(() ->
+                response -> Platform.runLater(() ->
                         showAlert(Alert.AlertType.INFORMATION, "テスト通知を送信しました")
                 ),
                 throwable -> {

--- a/slack/build.gradle
+++ b/slack/build.gradle
@@ -3,14 +3,11 @@ version = '1.4.0'
 
 def bundleName = description
 def rxJavaVersion = '2.2.21'
-def rxJavaFXVersion = '2.2.2'
 def reactiveStreamsVersion = '1.0.4'
 
 dependencies {
     implementation project(':commons')
     implementation "io.reactivex.rxjava2:rxjava:$rxJavaVersion"
-    implementation "io.reactivex.rxjava2:rxjavafx:$rxJavaFXVersion"
-    implementation "org.reactivestreams:reactive-streams:$reactiveStreamsVersion"
 }
 
 jar {

--- a/slack/build.gradle
+++ b/slack/build.gradle
@@ -2,12 +2,11 @@ description = 'Slack Plugin'
 version = '1.4.0'
 
 def bundleName = description
-def rxJavaVersion = '2.2.21'
-def reactiveStreamsVersion = '1.0.4'
+def reactorVersion = '3.7.12'
 
 dependencies {
     implementation project(':commons')
-    implementation "io.reactivex.rxjava2:rxjava:$rxJavaVersion"
+    implementation "io.projectreactor:reactor-core:$reactorVersion"
 }
 
 jar {

--- a/slack/src/main/java/plugins/slack/NotificationController.java
+++ b/slack/src/main/java/plugins/slack/NotificationController.java
@@ -1,7 +1,5 @@
 package plugins.slack;
 
-import io.reactivex.Flowable;
-import io.reactivex.schedulers.Schedulers;
 import logbook.Messages;
 import logbook.bean.*;
 import logbook.internal.Ships;
@@ -10,11 +8,11 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import plugins.slack.api.Pusher;
 import plugins.slack.bean.SlackConfig;
+import reactor.core.publisher.Flux;
 
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 /**
  * プッシュ通知コントローラ
@@ -33,8 +31,7 @@ public class NotificationController implements StartUp {
     @Override
     public void run() {
         // 起動時には通知を飛ばさないように1分待ってから監視を始める
-        Flowable.interval(60, 1, TimeUnit.SECONDS)
-                .observeOn(Schedulers.computation())
+        Flux.interval(Duration.ofSeconds(60), Duration.ofSeconds(1))
                 .subscribe(l -> update(), LoggerHolder::logError);
     }
 

--- a/slack/src/main/java/plugins/slack/api/Pusher.java
+++ b/slack/src/main/java/plugins/slack/api/Pusher.java
@@ -1,6 +1,5 @@
 package plugins.slack.api;
 
-import io.reactivex.functions.Consumer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -9,6 +8,7 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.util.function.Consumer;
 
 public class Pusher {
     private final String incomingWebhookUrl;
@@ -52,11 +52,7 @@ public class Pusher {
                 }
             } catch (Exception e) {
                 if (onError != null) {
-                    try {
-                        onError.accept(e);
-                    } catch (Exception ex) {
-                        throw new RuntimeException(ex);
-                    }
+                    onError.accept(e);
                 } else {
                     LoggerHolder.logError(e);
                 }

--- a/slack/src/main/java/plugins/slack/gui/SlackConfigController.java
+++ b/slack/src/main/java/plugins/slack/gui/SlackConfigController.java
@@ -75,7 +75,7 @@ public class SlackConfigController extends WindowController {
         new Pusher(incomingWebhookUrl.getText()).push(
                 "送信テスト",
                 "航海日誌 Slack Plugin より",
-                pushes -> Platform.runLater(() ->
+                response -> Platform.runLater(() ->
                         showAlert(Alert.AlertType.INFORMATION, "テスト通知を送信しました")
                 ),
                 throwable -> {


### PR DESCRIPTION
- Discord PluginとSlack Pluginのタイマー処理でReactor CoreのFluxを使う
- Discord Webhook送信成功時のステータスコードを修正